### PR TITLE
Update actor.jl to implement text rendering

### DIFF
--- a/src/actor.jl
+++ b/src/actor.jl
@@ -4,6 +4,7 @@ mutable struct Actor
     surface::Ptr{SDL2.Surface}
     position::Rect
     scale::Vector{Float64}
+    center::Vector{Int}
     angle::Float64
     data::Dict{Symbol, Any}
 end

--- a/src/actor.jl
+++ b/src/actor.jl
@@ -28,6 +28,25 @@ function Actor(image::String; kv...)
     return a
 end
 
+function ActorText(text::String, font_path::String, font_size=24, color=Int[255,255,0,255]; kv...)
+    font = SDL2.TTF_OpenFont(font_path, font_size)
+    sf = SDL2.TTF_RenderText_Blended(font, text, SDL2.Color(color...))
+    w, h = size(sf)
+    a = Actor(
+        text, 
+        sf, 
+        Rect(0, 0, Int(w), Int(h)), 
+        [1., 1.], 
+        [0, 0], 
+        0.0,
+        Dict{Symbol,Any}())
+
+    for (k, v) in kv
+        setproperty!(a, k, v)
+    end
+    return a
+end
+
 function Base.setproperty!(s::Actor, p::Symbol, x)
     if p == :image
         sf = image_surface(x)


### PR DESCRIPTION
Added `ActorText` function to create Actor objects using `SDL2.TTF_RenderText_Blended` for texture creation. The user must supply a `text` and a `font_path` to a TrueType font file. Defaults are provided for `font_size` and `color`.